### PR TITLE
Remove HTTP arguments from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gpsinflux
 
 Command-Line-Utility written in Python3.x for obtaining information via
-MTK GPS Modules and storing information (GPGGA) to InfluxDB either via UDP or HTTP.
+MTK GPS Modules and storing information (GPRMC) to InfluxDB either via UDP.
 
 
 ## Installation
@@ -16,28 +16,23 @@ __NOTE__: In order to use this script you need `sudo` rights to open a serial po
 
 
 ```
-    usage: gpsinflux [-h] [--serialport SERIALPORT] [--baudrate BAUDRATE]
-                 [--updaterate UPDATERATE] [--http] [--db-host DB_HOST]
-                 [--db-port DB_PORT] [--db-name DB_NAME] [--udp]
-                 [--udp-port UDP_PORT]
+usage: gpsinflux [-h] [--serialport SERIALPORT] [--baudrate BAUDRATE]
+               [--updaterate UPDATERATE] [--db-host DB_HOST]
+               [--db-port DB_PORT] [--udp-port UDP_PORT]
 
-    CLI for acquiring GPS values and storing it in InfluxDB
+CLI for acquiring GPS values and storing it in InfluxDB
 
-    optional arguments:
-    -h, --help            show this help message and exit
-    --serialport SERIALPORT
+optional arguments:
+  -h, --help            show this help message and exit
+  --serialport SERIALPORT
                         Serial Port for GPS Module
-    --baudrate BAUDRATE   Baud Rate for GPS Module Default: 9600
-    --updaterate UPDATERATE
+  --baudrate BAUDRATE   Baud Rate for GPS Module Default: 9600
+  --updaterate UPDATERATE
                         Update Rate for GPS Module in ms. Default: 1000ms
-    --http                Send GPS data via HTTP. Default: Disabled
-    --db-host DB_HOST     hostname for InfluxDB HTTP Instance. Default:
-                        localhost
-    --db-port DB_PORT     port number for InfluxDB HTTP Instance. Default: 8086
-    --db-name DB_NAME     database name to add GPS values to
-    --udp                 Send sensor via UDP. Default: Enabled
-    --udp-port UDP_PORT   UDP Port for sending information via UDP. Should also
-                        be configured in InfluxDB
+  --db-host DB_HOST     hostname for InfluxDB. Default: `localhost`
+  --db-port DB_PORT     port number for InfluxDB. Default: 8086
+  --udp-port UDP_PORT   UDP Port for sending information via UDP. Should also
+                        be configured in `influxdb.conf`
 
 ```
 
@@ -46,40 +41,23 @@ __NOTE__: In order to use this script you need `sudo` rights to open a serial po
 
 if no parameters are provided then the configuration from `/etc/umg/conf.json` is taken.
 
-     # starts according to conf.json in /etc/umg/ folder
+     # starts according to conf.json in `/etc/umg/` folder
      # gpsinflux
 
 Basic configuration can be found in `conf.json` file. Make sure to move this file into your `/etc` folder.
 
 
 ## Custom
+The `influxdb.conf` should have `[[udp]]` configured for port 20001 with a database to store the data.
 
-Serial Port for the GPS device is mandatory
-
-### UDP
-
-1. Serial Port of the GPS Module (mandatory)
-
-2. UDP Port value (mandatory)
-
-        $ gpsinflux --udp --udp-port 20001 --serialport /dev/ttyUSB0
-
-
-### HTTP
-
-1. Serial Port of the GPS Module (mandatory)
-
-2. InfluxDB Database Name (mandatory)
-
-        $ gpsinflux --http --db-name gps --serialport /dev/ttyUSB0
-
+    $ gpsinflux --udp-port 20001 --serialport /dev/ttyUSB0
 
 ## Development
 
 Use `virtualenv` to create a test environment as follows:
 
-    virtualenv -p python3 testenv
-    . testenv/bin/activate
+    python -m venv venv
+    . venv/bin/activate
 
     pip install -e .
 

--- a/gpsinflux/gpsinflux.py
+++ b/gpsinflux/gpsinflux.py
@@ -129,13 +129,13 @@ def parse_args():
     parser.add_argument('--updaterate', type=int, required=False, default=1000, help='Update Rate for GPS Module in ms. Default: 1000ms')
 
     parser.add_argument('--db-host', type=str, required=False, default='localhost',
-                        help='hostname for InfluxDB HTTP Instance. Default: localhost')
+                        help='hostname for InfluxDB. Default: `localhost`')
 
     parser.add_argument('--db-port', type=int, required=False, default=8086,
-                        help='port number for InfluxDB HTTP Instance. Default: 8086')
+                        help='port number for InfluxDB. Default: 8086')
 
     parser.add_argument('--udp-port', type=int, required=False,
-                        help='UDP Port for sending information via UDP.\n Should also be configured in InfluxDB')
+                        help='UDP Port for sending information via UDP. Should also be configured in `influxdb.conf`')
 
     return parser.parse_args()
 


### PR DESCRIPTION
- Update documentation by removing HTTP information
- Default is always UDP.
- Improve the argument help texts